### PR TITLE
ci: test direct release backport workflows (sync-based)

### DIFF
--- a/.github/scripts/prepare-backport-checkout.sh
+++ b/.github/scripts/prepare-backport-checkout.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+target_branch="${1:?target branch is required}"
+commit_range="${2:?commit range is required}"
+workspace_branch="ci-backport-${target_branch//\//-}"
+
+git fetch --no-tags origin "${target_branch}"
+
+mapfile -t commits < <(git rev-list --reverse "${commit_range}")
+
+if [[ "${#commits[@]}" -eq 0 ]]; then
+  echo "No commits found in range ${commit_range}" >&2
+  exit 1
+fi
+
+git checkout -B "${workspace_branch}" "origin/${target_branch}"
+git cherry-pick -x "${commits[@]}"

--- a/.github/scripts/prepare-backport-checkout.sh
+++ b/.github/scripts/prepare-backport-checkout.sh
@@ -26,7 +26,10 @@ git fetch --no-tags origin "${target_branch}"
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-mapfile -t commits < <(git rev-list --reverse "${commit_range}")
+commits=()
+while IFS= read -r commit; do
+  commits+=("${commit}")
+done < <(git rev-list --reverse "${commit_range}")
 
 if [[ "${#commits[@]}" -eq 0 ]]; then
   echo "No commits found in range ${commit_range}" >&2

--- a/.github/scripts/prepare-backport-checkout.sh
+++ b/.github/scripts/prepare-backport-checkout.sh
@@ -23,6 +23,8 @@ commit_range="${2:?commit range is required}"
 workspace_branch="ci-backport-${target_branch//\//-}"
 
 git fetch --no-tags origin "${target_branch}"
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
 mapfile -t commits < <(git rev-list --reverse "${commit_range}")
 

--- a/.github/workflows/backport-ci.yml
+++ b/.github/workflows/backport-ci.yml
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Backport Compatibility
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  detect-targets:
+    name: Detect release backport targets
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.targets.outputs.targets }}
+      has_targets: ${{ steps.targets.outputs.has_targets }}
+    steps:
+      - name: Collect release labels
+        id: targets
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map((label) => label.name);
+            const targets = [...new Set(labels.filter((name) => /^release\/.+$/.test(name)))].sort();
+
+            core.info(`Backport targets: ${targets.join(", ") || "(none)"}`);
+            core.setOutput("targets", JSON.stringify(targets));
+            core.setOutput("has_targets", targets.length > 0 ? "true" : "false");
+
+  backport-ci:
+    name: Backport CI (${{ matrix.target }})
+    needs: detect-targets
+    if: ${{ needs.detect-targets.outputs.has_targets == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.detect-targets.outputs.targets) }}
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      checkout_ref: refs/pull/${{ github.event.pull_request.number }}/head
+      backport_target_branch: ${{ matrix.target }}
+      backport_commit_range: ${{ format('{0}..{1}', github.event.pull_request.base.sha, github.event.pull_request.head.sha) }}
+      job_name_suffix: ${{ format(' [backport {0}]', matrix.target) }}
+      summary_job_name: ${{ format('Backport CI ({0})', matrix.target) }}
+      run_frontend: true
+      run_scala: true
+      run_python: true
+      run_agent_service: true
+    secrets: inherit

--- a/.github/workflows/create-backport-pr.yml
+++ b/.github/workflows/create-backport-pr.yml
@@ -1,0 +1,139 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Direct Backport Push
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  checks: read
+  contents: write
+  pull-requests: read
+
+jobs:
+  discover:
+    name: Discover direct backport targets
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.discover.outputs.pr_number }}
+      targets: ${{ steps.discover.outputs.targets }}
+      has_targets: ${{ steps.discover.outputs.has_targets }}
+    steps:
+      - name: Resolve merged PR and green targets
+        id: discover
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const sha = context.sha;
+            const { owner, repo } = context.repo;
+
+            const response = await github.request(
+              "GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls",
+              {
+                owner,
+                repo,
+                commit_sha: sha,
+              }
+            );
+
+            const pullRequest = response.data.find((pr) => pr.merge_commit_sha === sha) ?? response.data[0];
+            if (!pullRequest) {
+              core.info(`No merged pull request is associated with ${sha}.`);
+              core.setOutput("pr_number", "");
+              core.setOutput("targets", "[]");
+              core.setOutput("has_targets", "false");
+              return;
+            }
+
+            const requestedTargets = [...new Set(
+              pullRequest.labels
+                .map((label) => label.name)
+                .filter((name) => /^release\/.+$/.test(name))
+            )].sort();
+
+            if (requestedTargets.length === 0) {
+              core.info(`PR #${pullRequest.number} does not request any backports.`);
+              core.setOutput("pr_number", String(pullRequest.number));
+              core.setOutput("targets", "[]");
+              core.setOutput("has_targets", "false");
+              return;
+            }
+
+            const checks = await github.request(
+              "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
+              {
+                owner,
+                repo,
+                ref: pullRequest.head.sha,
+                per_page: 100,
+              }
+            );
+
+            const greenTargets = requestedTargets.filter((target) =>
+              checks.data.check_runs.some(
+                (run) =>
+                  run.name === `Backport CI (${target})` &&
+                  run.status === "completed" &&
+                  run.conclusion === "success"
+              )
+            );
+
+            const skippedTargets = requestedTargets.filter((target) => !greenTargets.includes(target));
+            if (skippedTargets.length > 0) {
+              core.warning(`Skipping targets without a successful Backport CI run: ${skippedTargets.join(", ")}`);
+            }
+
+            core.setOutput("pr_number", String(pullRequest.number));
+            core.setOutput("targets", JSON.stringify(greenTargets));
+            core.setOutput("has_targets", greenTargets.length > 0 ? "true" : "false");
+
+  push-backports:
+    name: Push backport to ${{ matrix.target }}
+    needs: discover
+    if: ${{ needs.discover.outputs.has_targets == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.discover.outputs.targets) }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Cherry-pick merge commit onto target branch
+        env:
+          MERGE_SHA: ${{ github.sha }}
+          TARGET_BRANCH: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+
+          parent_count=$(git rev-list --parents -n 1 "${MERGE_SHA}" | awk '{print NF-1}')
+          if [[ "${parent_count}" -ne 1 ]]; then
+            echo "Direct backport expects a squash-merged commit on main. ${MERGE_SHA} has ${parent_count} parents." >&2
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch --no-tags origin "${TARGET_BRANCH}"
+          git checkout -B "${TARGET_BRANCH}" "origin/${TARGET_BRANCH}"
+          git cherry-pick -x "${MERGE_SHA}"
+          git push origin "HEAD:${TARGET_BRANCH}"

--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -17,14 +17,12 @@
 
 name: Build
 
-env:
-  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-  
 on:
   push:
     branches:
       - 'ci-enable/**'
       - 'main'
+      - 'release/**'
   pull_request:
   workflow_dispatch:
 
@@ -33,176 +31,12 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  frontend:
-    name: frontend (${{ matrix.os }}, 18)
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        include:
-          - os: macos-latest
-            arch: arm64
-          - os: ubuntu-latest
-            arch: x64
-          - os: windows-latest
-            arch: x64
-        node-version:
-          - 20.19.0
-    steps:
-      - name: Checkout Texera
-        uses: actions/checkout@v5
-      - name: Setup node
-        uses: actions/setup-node@v5
-        with:
-          node-version: ${{ matrix.node-version }}
-          architecture: ${{ matrix.arch }}
-      - uses: actions/cache@v4
-        with:
-          path: frontend/.yarn/cache
-          key: ${{ runner.os }}-${{ matrix.arch }}-${{ matrix.node-version }}-yarn-cache-v4-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch }}-${{ matrix.node-version }}-yarn-cache-v4-
-      - name: Prepare Yarn 4.14.1
-        run: corepack enable && corepack prepare yarn@4.14.1 --activate
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-      - name: Install dependency
-        timeout-minutes: 20
-        run: yarn --cwd frontend install --immutable --inline-builds --network-timeout=100000
-      - name: Lint with Prettier & ESLint
-        run: yarn --cwd frontend format:ci
-      - name: Run frontend unit tests
-        run: yarn --cwd frontend run test:ci
-      - name: Prod build
-        run: yarn --cwd frontend run build:ci
-
-  scala:
-    strategy:
-      matrix:
-        os: [ ubuntu-22.04 ]
-        java-version: [ 11 ]
-    runs-on: ${{ matrix.os }}
-    env:
-      JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
-      JVM_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
-
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-        # Add a health check so steps wait until Postgres is ready
-        options: >-
-          --health-cmd="pg_isready -U postgres"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-      - name: Setup JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 11
-      - name: Setup Python for Scala tests
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
-      - name: Show Python
-        run: python --version || python3 --version
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          if [ -f amber/requirements.txt ]; then pip install -r amber/requirements.txt; fi
-          if [ -f amber/operator-requirements.txt ]; then pip install -r amber/operator-requirements.txt; fi
-      - name: Setup sbt launcher
-        uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
-      - uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
-        with:
-          extraSbtFiles: '["*.sbt", "project/**.{scala,sbt}", "project/build.properties" ]'
-      - name: Lint with scalafmt
-        run: sbt scalafmtCheckAll
-      - name: Create Databases
-        run: |
-          psql -h localhost -U postgres -f sql/texera_ddl.sql
-          psql -h localhost -U postgres -f sql/iceberg_postgres_catalog.sql
-          psql -h localhost -U postgres -f sql/texera_lakefs.sql
-        env:
-          PGPASSWORD: postgres
-      - name: Create texera_db_for_test_cases
-        run: psql -h localhost -U postgres -v DB_NAME=texera_db_for_test_cases -f sql/texera_ddl.sql
-        env:
-          PGPASSWORD: postgres
-      - name: Compile with sbt
-        run: sbt clean package
-      - name: Lint with scalafix
-        run: sbt "scalafixAll --check"
-      - name: Set docker-java API version
-        run: |
-          echo "api.version=1.52" >> ~/.docker-java.properties
-          cat ~/.docker-java.properties
-      - name: Run backend tests
-        run: sbt test
-
-  python:
-    strategy:
-      matrix:
-        os: [ ubuntu-latest ]
-        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout Texera
-        uses: actions/checkout@v5
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          if [ -f amber/requirements.txt ]; then pip install -r amber/requirements.txt; fi
-          if [ -f amber/operator-requirements.txt ]; then pip install -r amber/operator-requirements.txt; fi
-      - name: Install PostgreSQL
-        run: sudo apt-get update && sudo apt-get install -y postgresql
-      - name: Start PostgreSQL Service
-        run: sudo systemctl start postgresql
-      - name: Create Database and User
-        run: |
-          cd sql && sudo -u postgres psql -f iceberg_postgres_catalog.sql
-      - name: Lint with Ruff
-        run: |
-          cd amber/src/main/python && ruff check . && ruff format --check .
-      - name: Test with pytest
-        run: |
-          cd amber/src/main/python && pytest -sv
-
-  agent-service:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        bun-version: ['1.3.3']
-    defaults:
-      run:
-        working-directory: agent-service
-    steps:
-      - name: Checkout Texera
-        uses: actions/checkout@v5
-      - name: Setup Bun
-        run: |
-          curl -fsSL https://bun.sh/install | bash -s -- bun-v${{ matrix.bun-version }}
-          echo "$HOME/.bun/bin" >> $GITHUB_PATH
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-      - name: Lint with Prettier
-        run: bun run format:check
-      - name: Typecheck
-        run: bun run typecheck
-      - name: Run unit tests
-        run: bun test
+  build:
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      summary_job_name: Build Summary
+      run_frontend: true
+      run_scala: true
+      run_python: true
+      run_agent_service: true
+    secrets: inherit

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -1,0 +1,300 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Reusable Build
+
+on:
+  workflow_call:
+    inputs:
+      checkout_ref:
+        required: false
+        type: string
+        default: ""
+      backport_target_branch:
+        required: false
+        type: string
+        default: ""
+      backport_commit_range:
+        required: false
+        type: string
+        default: ""
+      job_name_suffix:
+        required: false
+        type: string
+        default: ""
+      run_frontend:
+        required: false
+        type: boolean
+        default: true
+      run_scala:
+        required: false
+        type: boolean
+        default: true
+      run_python:
+        required: false
+        type: boolean
+        default: true
+      run_agent_service:
+        required: false
+        type: boolean
+        default: true
+      summary_job_name:
+        required: false
+        type: string
+        default: "Build Summary"
+
+env:
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
+jobs:
+  frontend:
+    if: ${{ inputs.run_frontend }}
+    name: ${{ format('frontend{0} ({1}, 18)', inputs.job_name_suffix, matrix.os) }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: macos-latest
+            arch: arm64
+          - os: ubuntu-latest
+            arch: x64
+          - os: windows-latest
+            arch: x64
+        node-version:
+          - 20.19.0
+    steps:
+      - name: Checkout Texera
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
+          fetch-depth: 0
+      - name: Prepare backport workspace
+        if: ${{ inputs.backport_target_branch != '' }}
+        run: bash ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
+      - name: Setup node
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.node-version }}
+          architecture: ${{ matrix.arch }}
+      - uses: actions/cache@v4
+        with:
+          path: frontend/.yarn/cache
+          key: ${{ runner.os }}-${{ matrix.arch }}-${{ matrix.node-version }}-yarn-cache-v4-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.arch }}-${{ matrix.node-version }}-yarn-cache-v4-
+      - name: Prepare Yarn 4.14.1
+        run: corepack enable && corepack prepare yarn@4.14.1 --activate
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install dependency
+        timeout-minutes: 20
+        run: yarn --cwd frontend install --immutable --inline-builds --network-timeout=100000
+      - name: Lint with Prettier & ESLint
+        run: yarn --cwd frontend format:ci
+      - name: Run frontend unit tests
+        run: yarn --cwd frontend run test:ci
+      - name: Prod build
+        run: yarn --cwd frontend run build:ci
+
+  scala:
+    if: ${{ inputs.run_scala }}
+    name: ${{ format('scala{0} ({1}, 11)', inputs.job_name_suffix, matrix.os) }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+        java-version: [11]
+    runs-on: ${{ matrix.os }}
+    env:
+      JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+      JVM_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
+          fetch-depth: 0
+      - name: Prepare backport workspace
+        if: ${{ inputs.backport_target_branch != '' }}
+        run: bash ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: 11
+      - name: Setup Python for Scala tests
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Show Python
+        run: python --version || python3 --version
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f amber/requirements.txt ]; then pip install -r amber/requirements.txt; fi
+          if [ -f amber/operator-requirements.txt ]; then pip install -r amber/operator-requirements.txt; fi
+      - name: Setup sbt launcher
+        uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
+      - uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
+        with:
+          extraSbtFiles: '["*.sbt", "project/**.{scala,sbt}", "project/build.properties" ]'
+      - name: Lint with scalafmt
+        run: sbt scalafmtCheckAll
+      - name: Create Databases
+        run: |
+          psql -h localhost -U postgres -f sql/texera_ddl.sql
+          psql -h localhost -U postgres -f sql/iceberg_postgres_catalog.sql
+          psql -h localhost -U postgres -f sql/texera_lakefs.sql
+        env:
+          PGPASSWORD: postgres
+      - name: Create texera_db_for_test_cases
+        run: psql -h localhost -U postgres -v DB_NAME=texera_db_for_test_cases -f sql/texera_ddl.sql
+        env:
+          PGPASSWORD: postgres
+      - name: Compile with sbt
+        run: sbt clean package
+      - name: Lint with scalafix
+        run: sbt "scalafixAll --check"
+      - name: Set docker-java API version
+        run: |
+          echo "api.version=1.52" >> ~/.docker-java.properties
+          cat ~/.docker-java.properties
+      - name: Run backend tests
+        run: sbt test
+
+  python:
+    if: ${{ inputs.run_python }}
+    name: ${{ format('python{0} ({1}, {2})', inputs.job_name_suffix, matrix.os, matrix.python-version) }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Texera
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
+          fetch-depth: 0
+      - name: Prepare backport workspace
+        if: ${{ inputs.backport_target_branch != '' }}
+        run: bash ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f amber/requirements.txt ]; then pip install -r amber/requirements.txt; fi
+          if [ -f amber/operator-requirements.txt ]; then pip install -r amber/operator-requirements.txt; fi
+      - name: Install PostgreSQL
+        run: sudo apt-get update && sudo apt-get install -y postgresql
+      - name: Start PostgreSQL Service
+        run: sudo systemctl start postgresql
+      - name: Create Database and User
+        run: |
+          cd sql && sudo -u postgres psql -f iceberg_postgres_catalog.sql
+      - name: Lint with Ruff
+        run: |
+          cd amber/src/main/python && ruff check . && ruff format --check .
+      - name: Test with pytest
+        run: |
+          cd amber/src/main/python && pytest -sv
+
+  agent-service:
+    if: ${{ inputs.run_agent_service }}
+    name: ${{ format('agent-service{0} ({1})', inputs.job_name_suffix, matrix.os) }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        bun-version: ["1.3.3"]
+    defaults:
+      run:
+        working-directory: agent-service
+    steps:
+      - name: Checkout Texera
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
+          fetch-depth: 0
+      - name: Prepare backport workspace
+        if: ${{ inputs.backport_target_branch != '' }}
+        run: bash ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
+      - name: Setup Bun
+        run: |
+          curl -fsSL https://bun.sh/install | bash -s -- bun-v${{ matrix.bun-version }}
+          echo "$HOME/.bun/bin" >> $GITHUB_PATH
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Lint with Prettier
+        run: bun run format:check
+      - name: Typecheck
+        run: bun run typecheck
+      - name: Run unit tests
+        run: bun test
+
+  summary:
+    name: ${{ inputs.summary_job_name }}
+    if: ${{ always() }}
+    needs:
+      - frontend
+      - scala
+      - python
+      - agent-service
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any CI job failed
+        env:
+          FRONTEND_RESULT: ${{ needs.frontend.result }}
+          SCALA_RESULT: ${{ needs.scala.result }}
+          PYTHON_RESULT: ${{ needs.python.result }}
+          AGENT_SERVICE_RESULT: ${{ needs.agent-service.result }}
+          RUN_FRONTEND: ${{ inputs.run_frontend }}
+          RUN_SCALA: ${{ inputs.run_scala }}
+          RUN_PYTHON: ${{ inputs.run_python }}
+          RUN_AGENT_SERVICE: ${{ inputs.run_agent_service }}
+        run: |
+          check_result() {
+            local enabled="$1"
+            local result="$2"
+            if [[ "$enabled" == "true" && "$result" != "success" ]]; then
+              echo "A required CI job failed: $result"
+              exit 1
+            fi
+          }
+
+          check_result "$RUN_FRONTEND" "$FRONTEND_RESULT"
+          check_result "$RUN_SCALA" "$SCALA_RESULT"
+          check_result "$RUN_PYTHON" "$PYTHON_RESULT"
+          check_result "$RUN_AGENT_SERVICE" "$AGENT_SERVICE_RESULT"

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Prepare backport workspace
         if: ${{ inputs.backport_target_branch != '' }}
         working-directory: ${{ github.workspace }}
-        run: ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
+        run: bash ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
       - name: Setup node
         uses: actions/setup-node@v5
         with:
@@ -146,7 +146,7 @@ jobs:
       - name: Prepare backport workspace
         if: ${{ inputs.backport_target_branch != '' }}
         working-directory: ${{ github.workspace }}
-        run: ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
+        run: bash ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
@@ -208,7 +208,7 @@ jobs:
           fetch-depth: 0
       - name: Prepare backport workspace
         if: ${{ inputs.backport_target_branch != '' }}
-        run: ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
+        run: bash ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
@@ -253,7 +253,7 @@ jobs:
       - name: Prepare backport workspace
         if: ${{ inputs.backport_target_branch != '' }}
         working-directory: ${{ github.workspace }}
-        run: ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
+        run: bash ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
       - name: Setup Bun
         run: |
           curl -fsSL https://bun.sh/install | bash -s -- bun-v${{ matrix.bun-version }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -85,7 +85,8 @@ jobs:
           fetch-depth: 0
       - name: Prepare backport workspace
         if: ${{ inputs.backport_target_branch != '' }}
-        run: bash ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
+        working-directory: ${{ github.workspace }}
+        run: ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
       - name: Setup node
         uses: actions/setup-node@v5
         with:
@@ -144,7 +145,8 @@ jobs:
           fetch-depth: 0
       - name: Prepare backport workspace
         if: ${{ inputs.backport_target_branch != '' }}
-        run: bash ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
+        working-directory: ${{ github.workspace }}
+        run: ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
@@ -206,7 +208,7 @@ jobs:
           fetch-depth: 0
       - name: Prepare backport workspace
         if: ${{ inputs.backport_target_branch != '' }}
-        run: bash ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
+        run: ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
@@ -250,7 +252,8 @@ jobs:
           fetch-depth: 0
       - name: Prepare backport workspace
         if: ${{ inputs.backport_target_branch != '' }}
-        run: bash ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
+        working-directory: ${{ github.workspace }}
+        run: ./.github/scripts/prepare-backport-checkout.sh "${{ inputs.backport_target_branch }}" "${{ inputs.backport_commit_range }}"
       - name: Setup Bun
         run: |
           curl -fsSL https://bun.sh/install | bash -s -- bun-v${{ matrix.bun-version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,8 @@ yarn format:fix
 ### 4. PR Review
 - [ ] Ask a Texera Committer (by commenting on the PR) to triage your PR, i.e., request a reviewer, and assign the PR to you.
 - [ ] Add appropriate labels such as `fix`, `enhancement`, `docs`, etc.
+- [ ] If the change should also land in a release branch, add the release branch label directly, such as `release/1.1`.
+- [ ] When a `release/*` label is present, GitHub Actions will run the PR changes against that target release branch and, after the PR is squash-merged into `main`, automatically push the same change to the labeled release branch if the backport CI passed.
 - [ ] Ensure that all CI checks pass (see [GitHub Actions](https://github.com/Texera/texera/actions)).
 - [ ] Fully test your changes locally.
 


### PR DESCRIPTION
Temporary fork-only PR to validate release label backport workflows on a fork main synced with apache/texera main.

This PR tests:
- release/* label detection
- backport CI against a release branch cut from synced fork main
- post-merge direct backport push behavior
