### PR TITLE
test: conflicting backport onto behind release branch

### DIFF
--- a/.codex-backport/conflict.txt
+++ b/.codex-backport/conflict.txt
@@ -1,0 +1,1 @@
+main branch version


### PR DESCRIPTION
Backport CI test: target release branch contains a conflicting add/add change, so the backport prepare step should fail.