### PR TITLE
test: clean backport onto behind release branch

### DIFF
--- a/.codex-backport/clean-pass.txt
+++ b/.codex-backport/clean-pass.txt
@@ -1,0 +1,1 @@
+clean backport should cherry-pick onto an older release branch


### PR DESCRIPTION
Backport CI test: target release branch is intentionally behind main by several commits, but this change should cherry-pick cleanly.