### PR TITLE
test: clean backport CI on behind release branch

### DIFF
--- a/.codex-backport/clean-pass.txt
+++ b/.codex-backport/clean-pass.txt
@@ -1,0 +1,1 @@
+clean backport should cherry-pick onto an older release branch


### PR DESCRIPTION
Backport CI test against a release branch that is behind the base branch by several commits, but the scenario change should cherry-pick cleanly.