### PR TITLE
test: conflicting backport CI on behind release branch

### DIFF
--- a/.codex-backport/conflict.txt
+++ b/.codex-backport/conflict.txt
@@ -1,0 +1,1 @@
+main branch version


### PR DESCRIPTION
Backport CI test against a release branch that is behind the base branch and contains an add/add conflict for the same path.