### PR TITLE
test(case-2): clean backport on behind release branch

### DIFF
--- a/.codex-backport/clean-pass.txt
+++ b/.codex-backport/clean-pass.txt
@@ -1,0 +1,1 @@
+case 2: clean backport onto behind release branch


### PR DESCRIPTION
Test case 2: target `release/behind-clean` is older than the PR base but the cherry-pick should still apply cleanly (different files).

Expected: backport CI green for `release/behind-clean`.