### PR TITLE
test(case-3): conflicting backport on behind release branch

### DIFF
--- a/.codex-backport/conflict.txt
+++ b/.codex-backport/conflict.txt
@@ -1,0 +1,1 @@
+main branch version


### PR DESCRIPTION
Test case 3: target `release/conflict-addadd` already has `.codex-backport/conflict.txt` with a different version. The PR adds the same path with different content, so cherry-pick should hit an add/add conflict.

Expected: backport CI red on `release/conflict-addadd` at the Prepare backport workspace step.